### PR TITLE
Adding 304 HTTP status for gravatar verification

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/gravatar/GravatarImageURLVerifier.java
+++ b/src/main/java/org/jenkinsci/plugins/gravatar/GravatarImageURLVerifier.java
@@ -59,7 +59,8 @@ class GravatarImageURLVerifier {
             connection.setReadTimeout(5*1000);
             connection.setRequestMethod("HEAD");
             connection.connect();
-            gravtarExistsForEmail = (connection.getResponseCode() == HttpURLConnection.HTTP_OK);
+            int gravtarResponseCode = connection.getResponseCode();
+            gravtarExistsForEmail = (gravtarResponseCode == HttpURLConnection.HTTP_OK) || (gravtarResponseCode == HttpURLConnection.HTTP_NOT_MODIFIED);
             connection.disconnect();
         } catch (MalformedURLException e) {
             LOGGER.warning("Gravatar URL is malformed, " + imageURL);


### PR DESCRIPTION
Because the HTTP status code of 304 simply means that it is unmodified,  a 304 response should not cause a false verification for the email.
